### PR TITLE
Use PHP5.6 socket also in symfony nginx config.

### DIFF
--- a/scripts/serve-symfony2.sh
+++ b/scripts/serve-symfony2.sh
@@ -32,7 +32,7 @@ block="server {
     # DEV
     location ~ ^/(app_dev|config)\.php(/|\$) {
         fastcgi_split_path_info ^(.+\.php)(/.+)\$;
-        fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+        fastcgi_pass unix:/var/run/php5-fpm.sock;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
 
@@ -44,7 +44,7 @@ block="server {
     # PROD
     location ~ ^/app\.php(/|$) {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+        fastcgi_pass unix:/var/run/php5-fpm.sock;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
 
@@ -66,4 +66,4 @@ block="server {
 echo "$block" > "/etc/nginx/sites-available/$1"
 ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
 service nginx restart
-service php7.0-fpm restart
+service php5-fpm restart


### PR DESCRIPTION
The *serve-symfony.sh* script still contains the original PHP 7 socket from the original homestead box.