### PR TITLE
`--connect-expired-password` flag is used for mysql setup

### DIFF
--- a/scripts/create-mysql.sh
+++ b/scripts/create-mysql.sh
@@ -2,4 +2,7 @@
 
 DB=$1;
 
+mysql -uhomestead -psecret -e "SET PASSWORD  = PASSWORD('secret')" --connect-expired-password;
+mysql -uroot -psecret -e "SET PASSWORD  = PASSWORD('secret')" --connect-expired-password;
+
 mysql -uhomestead -psecret -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci";


### PR DESCRIPTION
On building new Virtualbox I was getting this error, `SQLSTATE[HY000] [1862] Your password has expired.`

The changes set a password using the `--connect-expired-password` and new builds work again.

The changes taken from here, http://stackoverflow.com/questions/40476412/mysql-password-expired-using-homestead-virtualbox